### PR TITLE
UI: Uniformity between Income and Expense Pages

### DIFF
--- a/client/src/components/ExpenseAdder/ExpenseAdder.styles.ts
+++ b/client/src/components/ExpenseAdder/ExpenseAdder.styles.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { motion } from "framer-motion";
 
 interface ExpenseProps {
-    long?: boolean;
+  long?: boolean;
 }
 
 export const Container = styled(motion.div)`
@@ -28,6 +28,7 @@ export const Button = styled.button`
   border: none;
   &:hover {
     color: lightgray;
+    cursor: pointer;
   }
 `;
 
@@ -56,6 +57,7 @@ export const Input = styled.input`
   border-radius: 5px;
   width: 100%;
   transition: 0.3s ease all;
+  margin-top: 0.5em;
   &:focus {
     box-shadow: 0 0 15px rgba(211, 174, 139, 1);
     border-radius: 3px;

--- a/client/src/components/ExpenseAdder/ExpenseAdder.tsx
+++ b/client/src/components/ExpenseAdder/ExpenseAdder.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Container,
   TitleContainer,
@@ -12,13 +12,29 @@ import {
   FormButton,
 } from "./ExpenseAdder.styles";
 import { MdOutlineCancel } from "react-icons/md";
+import { ExpenseData } from "../../pages/Expenses/Expenses";
 
-interface ExpenseProps {
-    setDisplayAdder: React.Dispatch<React.SetStateAction<boolean>>;
+interface ExpenseAdderProps {
+  setDisplayAdder: React.Dispatch<React.SetStateAction<boolean>>;
+  addItem: (newItem: ExpenseData) => void;
 }
 
-const ExpenseAdder: React.FC<ExpenseProps> = ({ setDisplayAdder }) => {
-  const handleSubmit = () => {};
+const ExpenseAdder: React.FC<ExpenseAdderProps> = ({
+  setDisplayAdder,
+  addItem,
+}) => {
+  const [title, setTitle] = useState<string>("");
+  const [amount, setAmount] = useState<number>(0);
+
+  const handleSubmit = (
+    newItem: ExpenseData,
+    e: React.FormEvent<HTMLFormElement>
+  ) => {
+    e.preventDefault();
+    addItem(newItem);
+    setTitle("");
+    setAmount(0);
+  };
 
   return (
     <Container
@@ -28,21 +44,31 @@ const ExpenseAdder: React.FC<ExpenseProps> = ({ setDisplayAdder }) => {
       exit={{ y: -20, opacity: 0, transition: { duration: 0.1 } }}
     >
       <TitleContainer>
-        <Title>Add your Expense</Title>
+        <Title>Add your income</Title>
         <Button onClick={() => setDisplayAdder(false)}>
-          <MdOutlineCancel size="1.5rem" />
+          <MdOutlineCancel size="2rem" />
         </Button>
       </TitleContainer>
 
-      <ExpenseForm onSubmit={handleSubmit}>
+      <ExpenseForm
+        onSubmit={(e) => handleSubmit({ id: 123, title, amount }, e)}
+      >
         <InputContainer>
           <InputGroup long>
             <Label>Title</Label>
-            <Input type="text" />
+            <Input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
           </InputGroup>
           <InputGroup>
             <Label>Amount</Label>
-            <Input type="number" />
+            <Input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(parseFloat(e.target.value))}
+            />
           </InputGroup>
         </InputContainer>
         <FormButton type="submit">Add Expense</FormButton>

--- a/client/src/components/ExpenseAdder/ExpenseAdder.tsx
+++ b/client/src/components/ExpenseAdder/ExpenseAdder.tsx
@@ -44,7 +44,7 @@ const ExpenseAdder: React.FC<ExpenseAdderProps> = ({
       exit={{ y: -20, opacity: 0, transition: { duration: 0.1 } }}
     >
       <TitleContainer>
-        <Title>Add your income</Title>
+        <Title>Add your expense</Title>
         <Button onClick={() => setDisplayAdder(false)}>
           <MdOutlineCancel size="2rem" />
         </Button>

--- a/client/src/components/ExpenseItem/ExpenseItem.styles.ts
+++ b/client/src/components/ExpenseItem/ExpenseItem.styles.ts
@@ -1,16 +1,54 @@
 import styled from "styled-components";
+import { motion } from "framer-motion";
 
-export const Container = styled.div`
-    display: flex;
-    justify-content: space-between;
-    padding: 1em;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+interface ButtonProps {
+  blueHover?: boolean;
+}
+
+export const Container = styled(motion.div)`
+  display: flex;
+`;
+
+export const ItemContainer = styled(motion.div)`
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  padding: 1em;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+
+  &:hover {
+    background-color: whitesmoke;
+    cursor: pointer;
+  }
 `;
 
 export const ItemName = styled.h3`
-    font-weight: 400;
+  font-weight: 400;
 `;
 
 export const ItemAmount = styled.h3`
-    color: red;
+  color: #ff595e;
+`;
+
+export const ItemOptionsContainer = styled(motion.div)`
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  background-color: lightgray;
+  padding: 0 1em;
+  box-sizing: border-box;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 5px 0px,
+    rgba(0, 0, 0, 0.1) 0px 0px 1px 0px;
+`;
+
+export const ItemOption = styled.button<ButtonProps>`
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: 0.2s ease all;
+
+  &:hover {
+    transform: scale(1.1);
+    color: ${(props) => (props.blueHover ? "blue" : "red")};
+  }
 `;

--- a/client/src/components/ExpenseItem/ExpenseItem.tsx
+++ b/client/src/components/ExpenseItem/ExpenseItem.tsx
@@ -1,19 +1,68 @@
-import React from "react";
-import { Container, ItemName, ItemAmount } from "./ExpenseItem.styles";
+import React, { useState } from "react";
+import {
+  Container,
+  ItemName,
+  ItemAmount,
+  ItemOptionsContainer,
+  ItemContainer,
+  ItemOption,
+} from "./ExpenseItem.styles";
+import { RiDeleteBin6Line, RiEditLine } from "react-icons/ri";
 
-interface ExpenseProps {
-    id: number;
-    title: string;
-    amount: number;
+interface ExpenseDataProps {
+  id: number;
+  title: string;
+  amount: number;
+  deleteItem: (targetId: number) => void;
 }
 
-const ExpenseItem: React.FC<ExpenseProps> = ({ id, title, amount }) => {
-    return (
-        <Container>
-            <ItemName>{title}</ItemName>
-            <ItemAmount>{`$${amount.toFixed(2)}`}</ItemAmount>
-        </Container>
-    );
+const ExpenseItem: React.FC<ExpenseDataProps> = ({
+  id,
+  title,
+  amount,
+  deleteItem,
+}) => {
+  const [itemOptions, setItemOptions] = useState<boolean>(false);
+
+  const toggleItemOptions = () => setItemOptions(!itemOptions);
+
+  const handleEdit = () => {};
+
+  const handleDelete = (id: number) => {
+    deleteItem(id);
+  };
+
+  return (
+    <Container
+      exit={{
+        opacity: 0,
+        x: 500,
+        backgroundColor: "#D25E5D",
+        transition: { duration: 0.2 },
+      }}
+    >
+      <ItemContainer onClick={toggleItemOptions}>
+        <ItemName>{title}</ItemName>
+        <ItemAmount>{`$ ${amount.toFixed(2)}`}</ItemAmount>
+      </ItemContainer>
+      {/* Item Options slides out on Click of each item */}
+      {itemOptions && (
+        <ItemOptionsContainer
+          initial={{ x: 20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.1 }}
+          exit={{ x: 20, opacity: 0 }}
+        >
+          <ItemOption blueHover onClick={handleEdit}>
+            <RiEditLine size="1.5rem" />
+          </ItemOption>
+          <ItemOption onClick={() => handleDelete(id)}>
+            <RiDeleteBin6Line size="1.5rem" />
+          </ItemOption>
+        </ItemOptionsContainer>
+      )}
+    </Container>
+  );
 };
 
 export default ExpenseItem;

--- a/client/src/components/ExpenseTracker/ExpenseTracker.styles.ts
+++ b/client/src/components/ExpenseTracker/ExpenseTracker.styles.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   width: 100%;
+  margin-bottom: 1em;
 `;
 
 export const ExpenseContainer = styled.div`
@@ -26,7 +27,5 @@ export const Title = styled.h1``;
 export const Button = styled.button`
   background: none;
   border: none;
-  &:hover {
-    color: lightgray;
-  }
+  cursor: pointer;
 `;

--- a/client/src/components/ExpenseTracker/ExpenseTracker.tsx
+++ b/client/src/components/ExpenseTracker/ExpenseTracker.tsx
@@ -1,6 +1,6 @@
 import React from "react";
+import { ExpenseItem } from "../../components";
 import { BsPlusCircle } from "react-icons/bs";
-import { ExpenseItem, BudgetNavbar } from "../../components";
 import {
   Container,
   ExpenseContainer,
@@ -8,58 +8,43 @@ import {
   Title,
   Button,
 } from "./ExpenseTracker.styles";
+import { AnimatePresence } from "framer-motion";
+import { ExpenseData } from "../../pages/Expenses/Expenses";
 
-interface ExpensesProps {
-    id: number;
-    title: string;
-    amount: number;
+interface ExpenseTrackerProps {
+  setDisplayAdder: React.Dispatch<React.SetStateAction<boolean>>;
+  deleteItem: (targetId: number) => void;
+  filteredExpenseData: ExpenseData[];
 }
 
-interface ExpenseProps {
-    setDisplayAdder: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-//Dummy Items
-const dummyExpenseData: Array<ExpensesProps> = [
-    {
-      id: 1,
-      title: "Doordash",
-      amount: 59.50,
-    },
-    {
-      id: 2,
-      title: "Rent",
-      amount: 1900,
-    },
-    {
-      id: 3,
-      title: "Electricity",
-      amount: 220,
-    },
-];
-
-
-const ExpenseTracker: React.FC<ExpenseProps> = ({ setDisplayAdder }) => {
-    return (
-      <Container>
-        <ExpenseContainer>
-          <TitleContainer>
-            <Title>Monthly Expenses</Title>
-            <Button onClick={() => setDisplayAdder(true)}>
-              <BsPlusCircle size="1.5rem" />
-            </Button>
-          </TitleContainer>
-          {dummyExpenseData.map((item) => (
+const ExpenseTracker: React.FC<ExpenseTrackerProps> = ({
+  setDisplayAdder,
+  deleteItem,
+  filteredExpenseData,
+}) => {
+  return (
+    <Container>
+      <ExpenseContainer>
+        <TitleContainer>
+          <Title>Monthly Expenses</Title>
+          <Button onClick={() => setDisplayAdder(true)}>
+            <BsPlusCircle size="1.5rem" />
+          </Button>
+        </TitleContainer>
+        <AnimatePresence>
+          {filteredExpenseData.map((item) => (
             <ExpenseItem
               key={item.id}
               id={item.id}
               title={item.title}
               amount={item.amount}
+              deleteItem={deleteItem}
             />
           ))}
-        </ExpenseContainer>
-      </Container>
-    );
-  };
+        </AnimatePresence>
+      </ExpenseContainer>
+    </Container>
+  );
+};
 
 export default ExpenseTracker;

--- a/client/src/components/IncomeAdder/IncomeAdder.styles.ts
+++ b/client/src/components/IncomeAdder/IncomeAdder.styles.ts
@@ -26,7 +26,10 @@ export const Title = styled.h1``;
 export const Button = styled.button`
   background: none;
   border: none;
-  cursor: pointer;
+  &:hover {
+    color: lightgray;
+    cursor: pointer;
+  }
 `;
 
 export const IncomeForm = styled.form`
@@ -50,11 +53,11 @@ export const Input = styled.input`
   padding: 0.5em 0.2em;
   outline: none;
   border: none;
-  /* border-bottom: 1px solid black; */
   outline: 1px solid rgba(0, 0, 0, 0.3);
   border-radius: 5px;
   width: 100%;
   transition: 0.3s ease all;
+  margin-top: 0.5em;
 
   &:focus {
     box-shadow: 0 0 15px rgba(211, 174, 139, 1);

--- a/client/src/components/IncomeAdder/IncomeAdder.tsx
+++ b/client/src/components/IncomeAdder/IncomeAdder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState } from "react";
 import {
   Container,
   TitleContainer,

--- a/client/src/components/IncomeItem/IncomeItem.styles.ts
+++ b/client/src/components/IncomeItem/IncomeItem.styles.ts
@@ -27,7 +27,7 @@ export const ItemName = styled.h3`
 `;
 
 export const ItemAmount = styled.h3`
-  color: green;
+  color: #25a244;
 `;
 
 export const ItemOptionsContainer = styled(motion.div)`

--- a/client/src/components/IncomeItem/IncomeItem.tsx
+++ b/client/src/components/IncomeItem/IncomeItem.tsx
@@ -8,7 +8,6 @@ import {
   ItemOption,
 } from "./IncomeItem.styles";
 import { RiDeleteBin6Line, RiEditLine } from "react-icons/ri";
-import { AnimatePresence } from "framer-motion";
 
 interface ItemDataProps {
   id: number;
@@ -44,7 +43,7 @@ const IncomeItem: React.FC<ItemDataProps> = ({
     >
       <ItemContainer onClick={toggleItemOptions}>
         <ItemName>{title}</ItemName>
-        <ItemAmount>{`$${amount.toFixed(2)}`}</ItemAmount>
+        <ItemAmount>{`$ ${amount.toFixed(2)}`}</ItemAmount>
       </ItemContainer>
       {/* Item Options slides out on Click of each item */}
       {itemOptions && (

--- a/client/src/components/IncomeTracker/IncomeTracker.tsx
+++ b/client/src/components/IncomeTracker/IncomeTracker.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { IncomeItem, BudgetNavbar } from "../../components";
+import React from "react";
+import { IncomeItem } from "../../components";
 import { BsPlusCircle } from "react-icons/bs";
 import {
   Container,

--- a/client/src/pages/Expenses/Expenses.styles.ts
+++ b/client/src/pages/Expenses/Expenses.styles.ts
@@ -1,4 +1,8 @@
 import styled from "styled-components";
 import { motion } from "framer-motion";
 
-export const Container = styled(motion.div)``;
+export const Container = styled(motion.div)`
+  width: 100vw;
+  max-width: 800px;
+  margin: 0 auto;
+`;

--- a/client/src/pages/Expenses/Expenses.tsx
+++ b/client/src/pages/Expenses/Expenses.tsx
@@ -1,10 +1,49 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Container } from "./Expenses.styles";
-
 import { ExpenseTracker, ExpenseAdder } from "../../components";
 import { AnimatePresence } from "framer-motion";
+
+export interface ExpenseData {
+  id: number;
+  title: string;
+  amount: number;
+}
+
+// Dummy Items for Expense
+const dummyExpenseData: Array<ExpenseData> = [
+  {
+    id: 1,
+    title: "Doordash",
+    amount: 59.5,
+  },
+  {
+    id: 2,
+    title: "Rent",
+    amount: 1900,
+  },
+  {
+    id: 3,
+    title: "Electricity",
+    amount: 220,
+  },
+];
+
 const Expenses = () => {
   const [displayAdder, setDisplayAdder] = useState<boolean>(false);
+  const [filteredExpenseData, setFilteredExpenseData] =
+    useState<Array<ExpenseData>>(dummyExpenseData);
+
+  useEffect(() => {}, [filteredExpenseData]);
+
+  const deleteItem = (targetId: number) => {
+    setFilteredExpenseData(
+      filteredExpenseData.filter((item) => item.id !== targetId)
+    );
+  };
+
+  const addItem = (newItem: ExpenseData) => {
+    setFilteredExpenseData([...filteredExpenseData, newItem]);
+  };
 
   return (
     <Container
@@ -13,10 +52,18 @@ const Expenses = () => {
       transition={{ duration: 0.35 }}
       exit={{ opacity: 0, y: -20 }}
     >
-      <ExpenseTracker setDisplayAdder={setDisplayAdder} />
       <AnimatePresence>
-        {displayAdder && <ExpenseAdder setDisplayAdder={setDisplayAdder} />}
+        {displayAdder && (
+          <ExpenseAdder setDisplayAdder={setDisplayAdder} addItem={addItem} />
+        )}
       </AnimatePresence>
+      <ExpenseTracker
+        setDisplayAdder={setDisplayAdder}
+        deleteItem={deleteItem}
+        filteredExpenseData={filteredExpenseData}
+      />
     </Container>
   );
+};
+
 export default Expenses;


### PR DESCRIPTION
Added the functionality to delete and add in Expense page uniform to Income Page

Things to work on:
- Styles sheet with with styled-components can be merged into one file and have conditional styling based on props between income item and expense item