### PR TITLE
Feat: Budget categories

### DIFF
--- a/server/src/Budgets/budget.module.ts
+++ b/server/src/Budgets/budget.module.ts
@@ -12,5 +12,6 @@ import { BudgetController } from './budget.controller';
   ],
   providers: [BudgetServices],
   controllers: [BudgetController],
+  exports: [BudgetServices],
 })
 export class BudgetModule {}

--- a/server/src/Budgets/budget.service.ts
+++ b/server/src/Budgets/budget.service.ts
@@ -10,10 +10,11 @@ import {
   BudgetDummyData,
   BudgetInterface,
 } from './dataStructureFiles/budget.interfaces';
+import { createBudgetObjects } from './utils';
 import { MongoDBID } from 'src/shared/types';
 import { User } from 'src/Auth/dataStructureFiles/auth.interfaces';
 import { BudgetDTO } from './dataStructureFiles/budget.dto';
-import { createBudgetObjects } from './utils';
+import { CATEGORIES } from './constants';
 
 @Injectable()
 export class BudgetServices {
@@ -32,9 +33,17 @@ export class BudgetServices {
     newBudget.last_date_edited = dateStamp();
     newBudget.user_id = user._id;
     newBudget.created = true;
+    CATEGORIES.forEach((category) =>
+      newBudget.categories.push({
+        title: category.title,
+        amount: category.amount,
+        transactions: category.transactions,
+      })
+    );
     return newBudget.save();
   }
 
+  // getAllBudgets
   async getAllBudgets(
     user: User
   ): Promise<BudgetInterface[] | BudgetDummyData[]> {
@@ -58,6 +67,17 @@ export class BudgetServices {
       return allBudgetOptions;
     }
     throw new UnauthorizedException('User must own budgets');
+  }
+
+  //getAllCreatedBudgets
+  async getAllCreatedBudgets(user: User): Promise<BudgetInterface[]> {
+    const allBudgets = await this.budgetModel.find().exec();
+    if (allBudgets) {
+      const currentUserBudgets = allBudgets.filter(
+        (budget) => budget.user_id === user.id
+      );
+      return currentUserBudgets;
+    }
   }
 
   async editBudget(

--- a/server/src/Budgets/constants.ts
+++ b/server/src/Budgets/constants.ts
@@ -1,0 +1,14 @@
+export const CATEGORIES = [
+  { title: 'Income', amount: 0, transactions: [] },
+  { title: 'Giving', amount: 0, transactions: [] },
+  { title: 'Savings', amount: 0, transactions: [] },
+  { title: 'Housing', amount: 0, transactions: [] },
+  { title: 'Transportation', amount: 0, transactions: [] },
+  { title: 'Food', amount: 0, transactions: [] },
+  { title: 'Personal', amount: 0, transactions: [] },
+  { title: 'Lifestyle', amount: 0, transactions: [] },
+  { title: 'Health', amount: 0, transactions: [] },
+  { title: 'Insurance', amount: 0, transactions: [] },
+  { title: 'Debt', amount: 0, transactions: [] },
+  { title: 'Uncategorized', amount: 0, transactions: [] },
+];

--- a/server/src/Budgets/dataStructureFiles/budget.interfaces.ts
+++ b/server/src/Budgets/dataStructureFiles/budget.interfaces.ts
@@ -1,5 +1,6 @@
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 import { MongoDBID } from 'src/shared/types';
+import { TransactionInterface } from 'src/Transactions/dataStructureFiles/transaction.interfaces';
 
 export interface BudgetInterface extends Document {
   readonly title: string;
@@ -9,6 +10,7 @@ export interface BudgetInterface extends Document {
   date_created: string;
   last_date_edited: String;
   user_id: MongoDBID;
+  categories: Types.DocumentArray<Category>;
 }
 
 export interface BudgetDummyData {
@@ -16,4 +18,9 @@ export interface BudgetDummyData {
   total: number;
   currentAmount: number;
   created: boolean;
+}
+export interface Category {
+  readonly title: string;
+  amount: number;
+  transactions: Types.DocumentArray<TransactionInterface>;
 }

--- a/server/src/Budgets/dataStructureFiles/budget.schema.ts
+++ b/server/src/Budgets/dataStructureFiles/budget.schema.ts
@@ -1,4 +1,11 @@
 import * as mongoose from 'mongoose';
+import { TransactionSchema } from 'src/Transactions/dataStructureFiles/transaction.schema';
+
+const categorySchema = new mongoose.Schema({
+  title: String,
+  amount: Number,
+  transactions: [TransactionSchema],
+});
 
 export const BudgetSchema = new mongoose.Schema({
   title: { type: String, required: true },
@@ -8,4 +15,5 @@ export const BudgetSchema = new mongoose.Schema({
   date_created: String,
   last_date_edited: String,
   user_id: String,
+  categories: [categorySchema],
 });

--- a/server/src/Transactions/dataStructureFiles/transaction.interfaces.ts
+++ b/server/src/Transactions/dataStructureFiles/transaction.interfaces.ts
@@ -14,4 +14,5 @@ export interface TransactionInterface extends Document {
   last_date_edited: String;
   user_id: MongoDBID;
   budget_id: MongoDBID;
+  category_id: MongoDBID;
 }

--- a/server/src/Transactions/dataStructureFiles/transaction.schema.ts
+++ b/server/src/Transactions/dataStructureFiles/transaction.schema.ts
@@ -8,4 +8,5 @@ export const TransactionSchema = new mongoose.Schema({
   last_date_edited: String,
   user_id: { type: String, required: true },
   budget_id: { type: String, required: true },
+  category_id: { type: String, required: true },
 });

--- a/server/src/Transactions/transaction.controller.ts
+++ b/server/src/Transactions/transaction.controller.ts
@@ -26,17 +26,19 @@ export class TransactionController {
 
   // TRANSACTION METHODS
   // Submit a transaction
-  @Post('/postTransaction/:budgetID')
+  @Post('/postTransaction/:budgetID/:categoryID')
   async addTransaction(
     @GetUser() user: User,
     @Res() res: Response,
     @Body() transactionDTO: TransactionDTO,
-    @Param('budgetID', new ValidateObjectId()) budgetID: MongoDBID
+    @Param('budgetID', new ValidateObjectId()) budgetID: MongoDBID,
+    @Param('categoryID', new ValidateObjectId()) categoryID: MongoDBID
   ) {
     const newTransaction = await this.transactionServices.addTransaction(
       transactionDTO,
       user,
-      budgetID
+      budgetID,
+      categoryID
     );
     return res.status(HttpStatus.OK).json({
       message: 'Transaction has been successfully added!',

--- a/server/src/Transactions/transaction.module.ts
+++ b/server/src/Transactions/transaction.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { AuthModule } from 'src/Auth/auth.module';
+import { BudgetModule } from 'src/Budgets/budget.module';
 import { TransactionSchema } from './dataStructureFiles/transaction.schema';
 import { TransactionController } from './transaction.controller';
 import { TransactionServices } from './transaction.service';
@@ -11,6 +12,7 @@ import { TransactionServices } from './transaction.service';
       { name: 'TransactionSchema', schema: TransactionSchema },
     ]),
     AuthModule,
+    BudgetModule,
   ],
   providers: [TransactionServices],
   controllers: [TransactionController],


### PR DESCRIPTION
In this PR: 

- You now have to include the params of budgetID and CategoryID when creating an income or expense.  My recommendation is that you set a piece of state when the user clicks a certain budget with the ID, then set the categoryID when they click on the drop down for the category.

- You should be able to get access to all budgets/categories/transactions now when you do the getAllBudgets function.  I can make one more specific if you want for getting a specific budget.  You may not need to use the getAllTransactions function anymore.  Let me know if we need it still or not.  Also, make sure that edit and delete still work for transactions.

- You still need to do the math on the front end and then save the new amounts to the backend.  The backend will store these amounts.

- getAllCreatedBudgets is not for you.  You can't access it from the front end currently.  Let me know if you need access to it and I can add it to a controller.

- Test all methods in postman if you can.