### PR TITLE
Fix: Transaction edit method and clean up

### DIFF
--- a/server/src/Budgets/budget.service.ts
+++ b/server/src/Budgets/budget.service.ts
@@ -80,6 +80,17 @@ export class BudgetServices {
     }
   }
 
+  async getBudgetById(
+    user: User,
+    budgetID: MongoDBID
+  ): Promise<BudgetInterface> {
+    const foundBudget = await this.budgetModel.findById(budgetID).exec();
+    if (user._id.toString() === foundBudget.user_id) {
+      return foundBudget;
+    }
+    throw new UnauthorizedException('User must own budget');
+  }
+
   async editBudget(
     user: User,
     budgetID: MongoDBID,

--- a/server/src/Transactions/dataStructureFiles/transaction.dto.ts
+++ b/server/src/Transactions/dataStructureFiles/transaction.dto.ts
@@ -1,3 +1,4 @@
+import { MongoDBID } from 'src/shared/types';
 import { IncomeOrExpense } from 'src/Transactions/dataStructureFiles/transaction.interfaces';
 
 export class TransactionDTO {
@@ -6,4 +7,5 @@ export class TransactionDTO {
   type: IncomeOrExpense;
   date_posted: string;
   last_date_edited: string;
+  category_id: MongoDBID;
 }

--- a/server/src/Transactions/dataStructureFiles/transaction.interfaces.ts
+++ b/server/src/Transactions/dataStructureFiles/transaction.interfaces.ts
@@ -7,8 +7,8 @@ export enum IncomeOrExpense {
 }
 
 export interface TransactionInterface extends Document {
-  readonly title: string;
-  readonly amount: number;
+  title: string;
+  amount: number;
   type: IncomeOrExpense;
   date_posted: string;
   last_date_edited: String;

--- a/server/src/Transactions/transaction.controller.ts
+++ b/server/src/Transactions/transaction.controller.ts
@@ -79,15 +79,20 @@ export class TransactionController {
   }
 
   // Edit a transaction using its ID
-  @Patch('/editTransaction/:transactionID')
+  @Patch('/editTransaction/:budgetID/:currentCategoryID/:transactionID')
   async editTransaction(
     @GetUser() user: User,
     @Res() res: Response,
+    @Param('budgetID', new ValidateObjectId()) budgetID: MongoDBID,
+    @Param('currentCategoryID', new ValidateObjectId())
+    currentCategoryID: MongoDBID,
     @Param('transactionID', new ValidateObjectId()) transactionID: MongoDBID,
     @Body() transactionDTO: TransactionDTO
   ) {
     const editableTransaction = await this.transactionServices.editTransaction(
       user,
+      budgetID,
+      currentCategoryID,
       transactionID,
       transactionDTO
     );
@@ -98,35 +103,25 @@ export class TransactionController {
   }
 
   // Delete a transaction using its ID
-  @Delete('/deleteTransaction/:transactionID')
+  @Delete('/deleteTransaction/:budgetID/:categoryID/:transactionID')
   async deleteTransaction(
     @GetUser() user: User,
     @Res() res: Response,
+    @Param('budgetID', new ValidateObjectId()) budgetID: MongoDBID,
+    @Param('categoryID', new ValidateObjectId())
+    categoryID: MongoDBID,
     @Param('transactionID', new ValidateObjectId()) transactionID: MongoDBID
   ) {
     const deletableTransaction =
-      await this.transactionServices.deleteTransaction(user, transactionID);
+      await this.transactionServices.deleteTransaction(
+        user,
+        budgetID,
+        categoryID,
+        transactionID
+      );
     return res.status(HttpStatus.OK).json({
       message: 'Transaction has been deleted!',
       deletedTransaction: deletableTransaction,
     });
   }
-
-  // Fetch a particular expense using its ID
-  // @Get('/getExpense/:expenseID')
-  // async getExpense(
-  //   @GetUser() user: User,
-  //   @Res() res: Response,
-  //   @Param('expenseID', new ValidateObjectId()) expenseID: MongoDBID
-  // ) {
-  //   const foundExpense = await this.transactionServices.getTransaction(
-  //     user._id,
-  //     expenseID,
-  //     IncomeOrExpense.EXPENSE
-  //   );
-  //   if (!foundExpense) {
-  //     throw new NotFoundException('Expense does not exist!');
-  //   }
-  //   return res.status(HttpStatus.OK).json(foundExpense);
-  // }
 }

--- a/server/src/Transactions/transaction.service.ts
+++ b/server/src/Transactions/transaction.service.ts
@@ -39,12 +39,13 @@ export class TransactionServices {
     newTransaction.user_id = user._id;
     newTransaction.budget_id = budget_id;
     newTransaction.category_id = category_id;
-    const allBudgets = await this.budgetServices.getAllCreatedBudgets(user);
-    const foundBudget = allBudgets.find((budget) => budget._id == budget_id);
+    const foundBudget = await this.budgetServices.getBudgetById(
+      user,
+      budget_id
+    );
     const foundCategory = foundBudget.categories.find(
       (category) => category._id == category_id
     );
-    newTransaction.save();
     foundCategory.transactions.push({
       title: newTransaction.title,
       amount: incomingDTO.amount,
@@ -57,21 +58,21 @@ export class TransactionServices {
       user_id: user._id,
       budget_id,
       category_id,
+      _id: newTransaction._id,
     });
+    newTransaction.save();
     foundBudget.save();
     return newTransaction;
   }
 
   // async getTransaction(
   //   userID: MongoDBID,
-  //   transactionID: MongoDBID,
-  //   transactionType: IncomeOrExpense
+  //   transactionID: MongoDBID
   // ): Promise<TransactionInterface> {
-  //   const transaction =
-  //     transactionType === 'income'
-  //       ? await this.incomeModel.findById(transactionID).exec()
-  //       : await this.expenseModel.findById(transactionID).exec();
-  //   if (userID === transaction.user_id) {
+  //   const transaction = await this.transactionModel
+  //     .findById(transactionID)
+  //     .exec();
+  //   if (userID == transaction.user_id) {
   //     return transaction;
   //   }
   //   throw new UnauthorizedException('User must own transaction');
@@ -94,9 +95,12 @@ export class TransactionServices {
 
   async editTransaction(
     user: User,
+    budgetID: MongoDBID,
+    currentCategoryID: MongoDBID,
     transactionID: MongoDBID,
     transactionDTO: TransactionDTO
   ): Promise<TransactionInterface> {
+    // send the new categoryID with the amount and title
     const editableTransaction = await this.transactionModel.findByIdAndUpdate(
       transactionID,
       transactionDTO,
@@ -105,6 +109,20 @@ export class TransactionServices {
       }
     );
     editableTransaction.last_date_edited = dateStamp();
+    const foundBudget = await this.budgetServices.getBudgetById(user, budgetID);
+    const foundCategory = foundBudget.categories.find(
+      (category) => category._id == currentCategoryID
+    );
+    foundCategory.transactions.forEach((transaction) => {
+      if (transaction._id.toString() === transactionID) {
+        transaction.title = editableTransaction.title;
+        transaction.amount = editableTransaction.amount;
+        transaction.type = editableTransaction.type;
+        transaction.last_date_edited = editableTransaction.last_date_edited;
+        transaction.category_id = editableTransaction.category_id;
+      }
+    });
+    foundBudget.save();
     if (editableTransaction === null) {
       throw new NotFoundException('Transaction does not exist!');
     } else if (user._id.toString() === editableTransaction.user_id) {
@@ -116,15 +134,31 @@ export class TransactionServices {
 
   async deleteTransaction(
     user: User,
+    budgetID: MongoDBID,
+    categoryID: MongoDBID,
     transactionID: MongoDBID
   ): Promise<
     TransactionInterface & {
       _id: MongoDBID;
     }
   > {
+    console.log('running');
+    const foundBudget = await this.budgetServices.getBudgetById(user, budgetID);
+    const foundCategory = foundBudget.categories.find(
+      (category) => category._id == categoryID
+    );
+    foundCategory.transactions.forEach((transaction) => {
+      if (transaction._id.toString() === transactionID) {
+        foundCategory.transactions.splice(
+          foundCategory.transactions.indexOf(transaction),
+          1
+        );
+      }
+    });
     const deletedtransaction = await this.transactionModel.findByIdAndRemove(
       transactionID
     );
+    foundBudget.save();
     if (deletedtransaction === null) {
       throw new NotFoundException('Transaction was already deleted.');
     } else if (user._id.toString() === deletedtransaction.user_id) {

--- a/server/src/Transactions/transaction.service.ts
+++ b/server/src/Transactions/transaction.service.ts
@@ -108,6 +108,10 @@ export class TransactionServices {
         new: true,
       }
     );
+    editableTransaction.type =
+      transactionDTO.amount < 0
+        ? IncomeOrExpense.EXPENSE
+        : IncomeOrExpense.INCOME;
     editableTransaction.last_date_edited = dateStamp();
     const foundBudget = await this.budgetServices.getBudgetById(user, budgetID);
     const foundCategory = foundBudget.categories.find(


### PR DESCRIPTION
In this PR: 

- I fixed the edit method.
- I also fixed the delete method.
- I cleaned up the methods a little bit.
- Before this implementation, the methods were dealing directly with the database.  Now they are deleting and updating from the database and updating the budget object.
- As always, make sure to double check with postman.
- on the Edittransaction function, you will need to pass budgetID/currentCategoryID/transactionID to get the correct one.  Then you will need to pass the new categoryID where you would normally pass the edited amount/title.