### PR TITLE
Feat: Budget input format

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "^6.2.7",
         "react": "^17.0.2",
         "react-confetti": "^6.0.1",
+        "react-currency-input-field": "^3.6.4",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.27.1",
         "react-icons": "^4.3.1",
@@ -13398,6 +13399,14 @@
         "react": "^16.3.0 || ^17.0.1"
       }
     },
+    "node_modules/react-currency-input-field": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/react-currency-input-field/-/react-currency-input-field-3.6.4.tgz",
+      "integrity": "sha512-0SifhqMirGt5+inzHslfbf71ZYoBt420pkMM6oBSGS40CsuPcLIOV19B1LPSCz7dWPGYi/kw5TOFQ0qALrn6Wg==",
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -26709,6 +26718,12 @@
       "requires": {
         "tween-functions": "^1.2.0"
       }
+    },
+    "react-currency-input-field": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/react-currency-input-field/-/react-currency-input-field-3.6.4.tgz",
+      "integrity": "sha512-0SifhqMirGt5+inzHslfbf71ZYoBt420pkMM6oBSGS40CsuPcLIOV19B1LPSCz7dWPGYi/kw5TOFQ0qALrn6Wg==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "framer-motion": "^6.2.7",
     "react": "^17.0.2",
     "react-confetti": "^6.0.1",
+    "react-currency-input-field": "^3.6.4",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.27.1",
     "react-icons": "^4.3.1",

--- a/client/src/components/BudgetAdder/BudgetAdder.styles.ts
+++ b/client/src/components/BudgetAdder/BudgetAdder.styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { motion } from "framer-motion";
+import CurrencyInput from "react-currency-input-field";
 
 interface InputBoxModifier {
   long?: boolean;
@@ -65,7 +66,7 @@ export const Label = styled.div`
   gap: 0.5em;
 `;
 
-export const Input = styled.input`
+export const Input = styled(CurrencyInput)`
   font-size: 1rem;
   padding: 0.5em 0.2em;
   outline: none;

--- a/client/src/components/BudgetAdder/BudgetAdder.tsx
+++ b/client/src/components/BudgetAdder/BudgetAdder.tsx
@@ -19,7 +19,7 @@ import { CreateBudgetSchema } from "../../constants";
 import { createBudget } from "../../API/BudgetMethods";
 
 interface FormInputs {
-  total: number;
+  total: string;
 }
 
 interface IBudgetAdder {
@@ -44,9 +44,10 @@ const BudgetAdder: React.FC<IBudgetAdder> = ({
   });
 
   const onSubmit: SubmitHandler<FormInputs> = (data) => {
+    const newTotal = data.total.replace("$", "").replace(",", "");
     createBudget({
       title,
-      total: data.total,
+      total: +newTotal,
       currentAmount,
     });
     setDisplayBudgetAdder(false);
@@ -69,7 +70,12 @@ const BudgetAdder: React.FC<IBudgetAdder> = ({
           <InputContainer>
             <InputGroup>
               <Label>Set a budget for the month:</Label>
-              <Input {...register("total")} />
+              <Input
+                placeholder="Please enter a budget amount"
+                prefix="$"
+                decimalScale={2}
+                {...register("total")}
+              />
               <ErrorContainer>
                 {errors.total && errors.total?.message && (
                   <p>{errors.total.message}</p>

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -104,12 +104,7 @@ export const TransactionSchema = yup.object().shape({
 
 export const CreateBudgetSchema = yup.object().shape({
   total: yup
-    .number()
-    .typeError("must be a number")
-    .positive("must be positive")
-    .min(0)
-    .test("maxDigitsAfterDecimal", "up to 2 decimals only", (amount: any) =>
-      /^\d+(\.\d{1,2})?$/.test(amount?.toString())
-    )
+    .string()
+    .matches(/^\$(0|[1-9][0-9]{0,2})(,\d{3})*(\.\d{1,2})?$/)
     .required("field is required"),
 });


### PR DESCRIPTION
In this PR:
- I added the React currency input field
- The package formats the value and turns it into a string.
- I am having to do some work to get it back into the right data shape before sending it to the backend.
- I also had to change the yup schema.

**This can also be applied to transactions if you want to.**