### PR TITLE
Fix: More budget amount formatting bugs

### DIFF
--- a/client/src/components/BudgetAdder/BudgetAdder.tsx
+++ b/client/src/components/BudgetAdder/BudgetAdder.tsx
@@ -73,6 +73,7 @@ const BudgetAdder: React.FC<IBudgetAdder> = ({
             <InputGroup>
               <Label>Set a budget for the month:</Label>
               <Input
+                autoComplete="off"
                 placeholder="Please enter a budget amount"
                 prefix="$"
                 decimalScale={2}

--- a/client/src/components/BudgetEditor/BudgetEditor.tsx
+++ b/client/src/components/BudgetEditor/BudgetEditor.tsx
@@ -82,6 +82,7 @@ const BudgetEditor: React.FC<IBudgetEditor> = ({
             <InputGroup>
               <Label>Edit your budget for the month:</Label>
               <Input
+                autoComplete="off"
                 placeholder="Please enter a budget amount"
                 prefix="$"
                 decimalScale={2}
@@ -95,7 +96,7 @@ const BudgetEditor: React.FC<IBudgetEditor> = ({
             </InputGroup>
           </InputContainer>
 
-          <FormButton type="submit">Save</FormButton>
+          <FormButton type="button">Save</FormButton>
         </CreateBudgetForm>
       </EditorContainer>
     </Container>


### PR DESCRIPTION
In this PR: 

- I turned autocomplete off and added the same logic to budgetEditor.