### PR TITLE
Various Fixes

### DIFF
--- a/client/src/components/BudgetCard/BudgetCard.styles.ts
+++ b/client/src/components/BudgetCard/BudgetCard.styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { motion } from "framer-motion";
+import { device } from "../../utils/Breakpoints";
 
 interface ProgressProp {
   percentage: number;
@@ -69,6 +70,14 @@ export const BudgetInfoContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  font-size: 0.7rem;
+
+  @media ${device.tablet} {
+    font-size: 1rem;
+  }
+  @media ${device.desktop} {
+    font-size: 1.1rem;
+  }
 `;
 
 export const BudgetInfo = styled.h3``;

--- a/client/src/components/BudgetCardList/BudgetCardList.styles.ts
+++ b/client/src/components/BudgetCardList/BudgetCardList.styles.ts
@@ -31,7 +31,7 @@ export const Carousel = styled(motion.div)`
 
 export const CurrentButton = styled.div`
   border-radius: 20px;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   border: 2px solid #3200c0;
   color: #3200c0;
   position: absolute;
@@ -44,6 +44,10 @@ export const CurrentButton = styled.div`
 
   &:hover {
     transform: scale(1.1);
+  }
+
+  @media ${device.tablet} {
+    font-size: 0.9rem;
   }
 
   @media ${device.desktop} {

--- a/client/src/components/Loading/Loading.styles.ts
+++ b/client/src/components/Loading/Loading.styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { motion } from "framer-motion";
+import { device } from "../../utils/Breakpoints";
 
 export const Container = styled(motion.div)`
   width: 100vw;
@@ -24,16 +25,20 @@ export const LoadingContainer = styled(motion.div)`
   padding: 2em;
   display: flex;
   flex-direction: column;
-  gap: 2em;
+  justify-content: space-between;
   align-items: center;
   position: relative;
   color: #542400;
+
+  @media ${device.desktop} {
+    min-height: 600px;
+  }
 `;
 
 export const LogoSection = styled.div``;
 
 export const Image = styled.img`
-  width: 180px;
+  width: 150px;
 `;
 
 export const Subtitle = styled.h3`
@@ -43,8 +48,12 @@ export const Subtitle = styled.h3`
 `;
 
 export const QuoteSection = styled.div`
-  text-align: center;
   background-color: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1em;
 `;
 
 export const InfoSection = styled.div`
@@ -52,25 +61,12 @@ export const InfoSection = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  height: 90%;
 `;
 
 export const Progress = styled.div``;
 
-export const CloseButton = styled.div`
-  position: absolute;
-  right: 2em;
-  top: 2em;
-  transition: 0.2s all ease;
-
-  &:hover {
-    transform: scale(1.05);
-  }
-`;
-
-export const DividerLine = styled.span`
-  height: 8px;
+export const DividerLine = styled.div`
+  height: 5px;
   width: 40px;
   background-color: #cc9b6d;
   display: block;

--- a/client/src/components/Loading/Loading.tsx
+++ b/client/src/components/Loading/Loading.tsx
@@ -35,17 +35,17 @@ const Loading = () => {
           <Image src={LogoImg} alt="logo" />
           <Subtitle>Tips</Subtitle>
         </LogoSection>
-        <DividerLine />
         <QuoteSection>
+          <DividerLine />
           {data && (
-            <h1>{data[Math.floor(Math.random() * data.length)].title}</h1>
+            <h2>{data[Math.floor(Math.random() * data.length)].title}</h2>
           )}
-        </QuoteSection>
-        <DividerLine />
-        <InfoSection>
+          <DividerLine />
           {data && (
             <h4>{data[Math.floor(Math.random() * data.length)].author}</h4>
           )}
+        </QuoteSection>
+        <InfoSection>
           <Progress>
             <p style={{ marginBottom: "1em" }}>Loading your content...</p>
             <CircularProgress style={{ color: "#3200c0" }} />

--- a/client/src/components/TransactionItem/TransactionItem.tsx
+++ b/client/src/components/TransactionItem/TransactionItem.tsx
@@ -21,6 +21,7 @@ interface Transaction {
   toggleRerender: () => void;
   pageType: TransactionType;
   categoryId: string;
+  doRefetch: () => void;
 }
 
 const TransactionItem: React.FC<Transaction> = ({
@@ -30,6 +31,7 @@ const TransactionItem: React.FC<Transaction> = ({
   toggleRerender,
   pageType,
   categoryId,
+  doRefetch,
 }) => {
   const [itemOptions, setItemOptions] = useState<boolean>(false);
   const [displayItemEditor, setDisplayItemEditor] = useState<boolean>(false);
@@ -51,6 +53,7 @@ const TransactionItem: React.FC<Transaction> = ({
       currentAmount:
         pageType === "expense" ? currentAmount + amount : currentAmount,
     });
+    doRefetch();
     toggleRerender();
   };
 

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -79,7 +79,11 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
       });
     doRefetch();
     toggleRerender();
-    reset();
+    reset({
+      title: "",
+      amount: "",
+    });
+    setDisplayAdder(false);
   };
 
   return (

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -12,7 +12,6 @@ import {
   FormButton,
   ErrorContainer,
   Select,
-  AmountInput,
 } from "./TransactionItemAdder.styles";
 import { MdOutlineCancel } from "react-icons/md";
 import { useForm, SubmitHandler } from "react-hook-form";
@@ -24,7 +23,7 @@ import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 
 interface FormInputs {
   title: string;
-  amount: string;
+  amount: number;
   categoryId: string;
 }
 
@@ -59,11 +58,10 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
   const navigate = useNavigate();
 
   const onSubmit: SubmitHandler<FormInputs> = (data): void => {
-    const newTotal = data.amount.replace("$", "").replace(",", "");
     addItem(
       {
         title: data.title,
-        amount: pageType === "expense" ? +newTotal * -1 : +newTotal,
+        amount: pageType === "expense" ? data.amount * -1 : data.amount,
         categoryId: data.categoryId,
       },
       budgetId,
@@ -75,15 +73,11 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
         title: title,
         total: total,
         currentAmount:
-          pageType === "expense" ? currentAmount + +newTotal : currentAmount,
+          pageType === "expense" ? currentAmount + data.amount : currentAmount,
       });
     doRefetch();
     toggleRerender();
-    reset({
-      title: "",
-      amount: "",
-    });
-    setDisplayAdder(false);
+    reset();
   };
 
   return (
@@ -115,12 +109,7 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
           </InputGroup>
           <InputGroup>
             <Label>Amount</Label>
-            <AmountInput
-              prefix="$"
-              decimalScale={2}
-              autoComplete="off"
-              {...register("amount")}
-            />
+            <Input autoComplete="off" {...register("amount")} />
             <ErrorContainer>
               {errors.amount && errors.amount?.message && (
                 <p>{errors.amount.message}</p>

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -51,6 +51,7 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
     handleSubmit,
     formState: { errors },
     reset,
+    setFocus,
   } = useForm<FormInputs>({
     resolver: yupResolver(TransactionSchema),
   });
@@ -78,6 +79,7 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
     doRefetch();
     toggleRerender();
     reset();
+    setFocus("title");
   };
 
   return (

--- a/client/src/components/TransactionItemsList/TransactionItemsList.tsx
+++ b/client/src/components/TransactionItemsList/TransactionItemsList.tsx
@@ -19,6 +19,7 @@ interface ITransactionItemsList {
   pageType: TransactionType;
   displayAdder: boolean;
   currentAmount: number;
+  doRefetch: () => void;
 }
 
 const TransactionItemsList: React.FC<ITransactionItemsList> = ({
@@ -28,6 +29,7 @@ const TransactionItemsList: React.FC<ITransactionItemsList> = ({
   pageType,
   displayAdder,
   currentAmount,
+  doRefetch,
 }) => {
   return (
     <Container>
@@ -55,6 +57,7 @@ const TransactionItemsList: React.FC<ITransactionItemsList> = ({
               amount={item.amount}
               toggleRerender={toggleRerender}
               pageType={pageType}
+              doRefetch={doRefetch}
             />
           ))}
         </AnimatePresence>

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -29,7 +29,7 @@ const Home: React.FC<IHome> = ({ displayLoader, setDisplayLoader }) => {
     if (displayLoader) {
       const loaderTimer = setTimeout(() => {
         setDisplayLoader(false);
-      }, 3000);
+      }, 5000);
       return () => clearTimeout(loaderTimer);
     }
   }, []);

--- a/client/src/pages/Transactions/Transactions.styles.ts
+++ b/client/src/pages/Transactions/Transactions.styles.ts
@@ -24,3 +24,9 @@ export const GotoBudgetButton = styled.a`
     transform: scale(1.05);
   }
 `;
+
+export const IncomeMessage = styled.div`
+  color: red;
+  font-size: 0.7rem;
+  text-align: center;
+`;

--- a/client/src/pages/Transactions/Transactions.tsx
+++ b/client/src/pages/Transactions/Transactions.tsx
@@ -73,6 +73,7 @@ const Transactions: React.FC<Transaction> = ({ pageType }) => {
           pageType={pageType}
           displayAdder={displayAdder}
           currentAmount={currentAmount}
+          doRefetch={doRefetch}
         />
         <GotoBudgetButton
           onClick={() => {

--- a/client/src/pages/Transactions/Transactions.tsx
+++ b/client/src/pages/Transactions/Transactions.tsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect, createContext } from "react";
-import { Container, GotoBudgetButton } from "./Transactions.styles";
+import {
+  Container,
+  GotoBudgetButton,
+  IncomeMessage,
+} from "./Transactions.styles";
 import { TransactionItemAdder, TransactionItemsList } from "../../components";
 import { AnimatePresence } from "framer-motion";
 import { getAllItems } from "../../API/TransactionMethods";
@@ -83,6 +87,11 @@ const Transactions: React.FC<Transaction> = ({ pageType }) => {
         >
           <MdKeyboardArrowLeft size="2rem" /> Back to Budget
         </GotoBudgetButton>
+        {pageType === "income" && (
+          <IncomeMessage>
+            <p>**Income transactions will not affect the budget.**</p>
+          </IncomeMessage>
+        )}
       </Container>
     </PathContext.Provider>
   );

--- a/client/src/utils/Breakpoints.ts
+++ b/client/src/utils/Breakpoints.ts
@@ -1,5 +1,5 @@
 const size = {
-  mobile: "425px",
+  mobile: "370px",
   tablet: "768px",
   desktop: "992px",
 };


### PR DESCRIPTION
- Loading container has been fixed so that it's now containing all of the content
- Transaction Adder is taken off the UI once user submits a new transaction (this was done because I could not figure out how to reset the amount input field that is using React-Currency-Input-Field package. useRef hook did not work..If we can figure out how to reset this, we I can revert back this change before the presentation)
- Added a little note in transactions page - if the pagetype is 'income' then itll show: **Income transactions will not affect the budget.** for clarification
- Deleted the currency formatting for TransactionAdder component for now
- Made the title input field the default focus whenever user submits
- I'll need to look further into why deleting a transaction is sometimes not reflected in the UI right away.