### PR TITLE
Transactions refactored + other fixes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { QueryClientProvider, QueryClient } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 const queryClient = new QueryClient();
 
@@ -70,6 +71,7 @@ function App() {
           </Routes>
         </Router>
       </div>
+      <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
     </QueryClientProvider>
   );
 }

--- a/client/src/components/BudgetEditor/BudgetEditor.tsx
+++ b/client/src/components/BudgetEditor/BudgetEditor.tsx
@@ -28,7 +28,7 @@ interface IBudgetEditor {
   currentBudget: number;
   setDisplayBudgetEditor: React.Dispatch<React.SetStateAction<boolean>>;
   currentAmount: number;
-  doRefetch: () => void;
+  refetchBudget: () => void;
   budgetId: string;
 }
 
@@ -37,7 +37,7 @@ const BudgetEditor: React.FC<IBudgetEditor> = ({
   currentBudget,
   setDisplayBudgetEditor,
   currentAmount,
-  doRefetch,
+  refetchBudget,
   budgetId,
 }) => {
   const preloadedValues = {
@@ -61,7 +61,7 @@ const BudgetEditor: React.FC<IBudgetEditor> = ({
       total: +newTotal,
       currentAmount,
     });
-    doRefetch();
+    refetchBudget();
     setDisplayBudgetEditor(false);
   };
 

--- a/client/src/components/TransactionItem/TransactionItem.tsx
+++ b/client/src/components/TransactionItem/TransactionItem.tsx
@@ -54,7 +54,6 @@ const TransactionItem: React.FC<Transaction> = ({
         pageType === "expense" ? currentAmount + amount : currentAmount,
     });
     await refetchBudget();
-    // toggleRerender();
   };
 
   const currencyFormatter = new Intl.NumberFormat("en-US", {

--- a/client/src/components/TransactionItem/TransactionItem.tsx
+++ b/client/src/components/TransactionItem/TransactionItem.tsx
@@ -21,7 +21,7 @@ interface Transaction {
   toggleRerender: () => void;
   pageType: TransactionType;
   categoryId: string;
-  doRefetch: () => void;
+  refetchBudget: () => void;
 }
 
 const TransactionItem: React.FC<Transaction> = ({
@@ -31,7 +31,7 @@ const TransactionItem: React.FC<Transaction> = ({
   toggleRerender,
   pageType,
   categoryId,
-  doRefetch,
+  refetchBudget,
 }) => {
   const [itemOptions, setItemOptions] = useState<boolean>(false);
   const [displayItemEditor, setDisplayItemEditor] = useState<boolean>(false);
@@ -45,16 +45,16 @@ const TransactionItem: React.FC<Transaction> = ({
 
   const navigate = useNavigate();
 
-  const handleDelete = () => {
-    deleteItem(budgetId, categoryId, itemId, navigate);
-    editBudget(navigate, _id, {
+  const handleDelete = async () => {
+    await deleteItem(budgetId, categoryId, itemId, navigate);
+    await editBudget(navigate, _id, {
       title: title,
       total: total,
       currentAmount:
         pageType === "expense" ? currentAmount + amount : currentAmount,
     });
-    doRefetch();
-    toggleRerender();
+    await refetchBudget();
+    // toggleRerender();
   };
 
   const currencyFormatter = new Intl.NumberFormat("en-US", {

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -35,14 +35,14 @@ interface ITransactionItemAdder {
   setDisplayAdder: React.Dispatch<React.SetStateAction<boolean>>;
   toggleRerender: () => void;
   pageType: TransactionType;
-  doRefetch: () => void;
+  refetchBudget: () => void;
 }
 
 const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
   setDisplayAdder,
   toggleRerender,
   pageType,
-  doRefetch,
+  refetchBudget,
 }) => {
   const { budgetId } = useParams();
 
@@ -62,8 +62,8 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
 
   const navigate = useNavigate();
 
-  const onSubmit: SubmitHandler<FormInputs> = (data): void => {
-    addItem(
+  const onSubmit: SubmitHandler<FormInputs> = async (data) => {
+    await addItem(
       {
         title: data.title,
         amount: pageType === "expense" ? data.amount * -1 : data.amount,
@@ -74,16 +74,16 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
       navigate
     );
     typeof _id === "string" &&
-      editBudget(navigate, _id, {
+      (await editBudget(navigate, _id, {
         title: title,
         total: total,
         currentAmount:
           pageType === "expense"
             ? +currentAmount + +data.amount
             : +currentAmount,
-      });
-    doRefetch();
-    toggleRerender();
+      }));
+    await refetchBudget();
+    // toggleRerender();
     reset();
     setFocus("title");
   };

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -74,7 +74,9 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
         title: title,
         total: total,
         currentAmount:
-          pageType === "expense" ? currentAmount + data.amount : currentAmount,
+          pageType === "expense"
+            ? +currentAmount + +data.amount
+            : +currentAmount,
       });
     doRefetch();
     toggleRerender();

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -83,7 +83,6 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
             : +currentAmount,
       }));
     await refetchBudget();
-    // toggleRerender();
     reset();
     setFocus("title");
   };

--- a/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
+++ b/client/src/components/TransactionItemAdder/TransactionItemAdder.tsx
@@ -18,7 +18,11 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { addItem } from "../../API/TransactionMethods";
 import { editBudget } from "../../API/BudgetMethods";
-import { TransactionType, TransactionSchema, ICategory } from "../../constants";
+import {
+  TransactionType,
+  TransactionAddSchema,
+  ICategory,
+} from "../../constants";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 
 interface FormInputs {
@@ -53,7 +57,7 @@ const TransactionItemAdder: React.FC<ITransactionItemAdder> = ({
     reset,
     setFocus,
   } = useForm<FormInputs>({
-    resolver: yupResolver(TransactionSchema),
+    resolver: yupResolver(TransactionAddSchema),
   });
 
   const navigate = useNavigate();

--- a/client/src/components/TransactionItemEditor/TransactionItemEditor.tsx
+++ b/client/src/components/TransactionItemEditor/TransactionItemEditor.tsx
@@ -71,9 +71,9 @@ const TransactionItemEditor: React.FC<TargetItem> = ({
   });
   const navigate = useNavigate();
 
-  const onSubmit: SubmitHandler<FormInputs> = (data) => {
-    const newTotal = data.amount.replace("$", "").replace(",", "");
-    editItem(
+  const onSubmit: SubmitHandler<FormInputs> = async (data) => {
+    const newTotal = await data.amount.replace("$", "").replace(",", "");
+    await editItem(
       budgetId,
       prevCategoryId,
       id,
@@ -85,7 +85,7 @@ const TransactionItemEditor: React.FC<TargetItem> = ({
       navigate
     );
     _id &&
-      editBudget(navigate, _id, {
+      (await editBudget(navigate, _id, {
         title: title,
         total: total,
         // NEED TO FIX THIS
@@ -93,7 +93,7 @@ const TransactionItemEditor: React.FC<TargetItem> = ({
           pageType === "expense"
             ? currentAmount + amount + +newTotal
             : currentAmount,
-      });
+      }));
     setItemOptions(false);
     setDisplayItemEditor(false);
     toggleRerender();

--- a/client/src/components/TransactionItemsList/TransactionItemsList.tsx
+++ b/client/src/components/TransactionItemsList/TransactionItemsList.tsx
@@ -19,7 +19,7 @@ interface ITransactionItemsList {
   pageType: TransactionType;
   displayAdder: boolean;
   currentAmount: number;
-  doRefetch: () => void;
+  refetchBudget: () => void;
 }
 
 const TransactionItemsList: React.FC<ITransactionItemsList> = ({
@@ -29,7 +29,7 @@ const TransactionItemsList: React.FC<ITransactionItemsList> = ({
   pageType,
   displayAdder,
   currentAmount,
-  doRefetch,
+  refetchBudget,
 }) => {
   return (
     <Container>
@@ -43,7 +43,7 @@ const TransactionItemsList: React.FC<ITransactionItemsList> = ({
           </Button>
         </TitleContainer>
         <AnimatePresence>
-          {filteredData.length < 1 && (
+          {filteredData?.length < 1 && (
             <NoTransactionsMessage>
               <h2>No transactions yet</h2>
             </NoTransactionsMessage>
@@ -57,7 +57,7 @@ const TransactionItemsList: React.FC<ITransactionItemsList> = ({
               amount={item.amount}
               toggleRerender={toggleRerender}
               pageType={pageType}
-              doRefetch={doRefetch}
+              refetchBudget={refetchBudget}
             />
           ))}
         </AnimatePresence>

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -100,6 +100,17 @@ export const TransactionSchema = yup.object().shape({
   amount: yup.string().required("field is required"),
 });
 
+export const TransactionAddSchema = yup.object().shape({
+  title: yup.string().min(2).max(50).required("field is required"),
+  amount: yup
+    .number()
+    .typeError("Must be a number")
+    .test("maxDigitsAfterDecimal", "up to 2 decimals only", (amount: any) =>
+      /^\d+(\.\d{1,2})?$/.test(amount?.toString())
+    )
+    .required("field is required"),
+});
+
 export const CreateBudgetSchema = yup.object().shape({
   total: yup.string().required("field is required"),
 });

--- a/client/src/pages/Budget/Budget.tsx
+++ b/client/src/pages/Budget/Budget.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Container } from "./Budget.styles";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "react-query";
@@ -18,9 +18,9 @@ const Budget = () => {
     fetchBudgetData
   );
 
-  const doRefetch = () => {
+  useEffect(() => {
     refetch();
-  };
+  }, [data]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -32,7 +32,7 @@ const Budget = () => {
 
   return (
     <Container>
-      <Outlet context={{ data, doRefetch }} />
+      <Outlet context={{ data, refetch }} />
     </Container>
   );
 };

--- a/client/src/pages/BudgetMain/BudgetMain.tsx
+++ b/client/src/pages/BudgetMain/BudgetMain.tsx
@@ -38,7 +38,7 @@ const BudgetMain: React.FC = () => {
   // I know this shouldn't be typed any...but I couldn't figure out how to type this along with the other useOutletContext ones
   const {
     data: { _id, title, currentAmount, total, categories },
-    doRefetch,
+    refetch,
   } = useOutletContext<any>();
   const [displayBudgetEditor, setDisplayBudgetEditor] =
     useState<boolean>(false);
@@ -120,7 +120,7 @@ const BudgetMain: React.FC = () => {
           setDisplayBudgetEditor={setDisplayBudgetEditor}
           currentBudget={total}
           currentAmount={currentAmount}
-          doRefetch={doRefetch}
+          refetchBudget={refetch}
           budgetId={_id}
         />
       )}

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -13,10 +13,12 @@ interface IHome {
 
 const Home: React.FC<IHome> = ({ displayLoader, setDisplayLoader }) => {
   const navigate = useNavigate();
+
   const fetchAllBudgets = async () => {
     const data = await getAllBudgets(navigate);
     return data;
   };
+
   const { data, isLoading, status, refetch } = useQuery(
     "budgets",
     fetchAllBudgets,


### PR DESCRIPTION
- Get all transactions method is no longer used. All the data being pulled from getBudgetByID is what is being used for transactions.
- Created a new Yup validator schema for Transaction Adder since it no longer used the React Currency Input Field
- Transaction Adder was not adding to the Budget's current amount correctly after taking off the currency formatting from transaction adder component - Should be fixed now